### PR TITLE
Bold highlighting and validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Settings set via element attributes have higher priority and override settings f
 * **minLength**: `(default: 1)` Number of characters that needs to be entered before the directive does any work.
 * **uniqueId**: an unique ID that will be used as an idenficator in emitted events. Comes handy when you have multiple instances of the directive on the page and need to identify which instance emitted particular event.
 * **boldMatches**: `(default: true)` Should the matches in suggestion be bold?
+* **boldHighlightsMatch**: `(default: false)` Should the matched part of a suggestion be bold or not (in which case, all *but* the matched part is displayed in bold)?
 * **templateUrl**: Path to your custom template.
 
 All attributes are optional and everything should work fine without any customization as far as the `getAutocompleteResults` method is defined in the scope ([more](#providing-data-for-the-directive)).

--- a/README.md
+++ b/README.md
@@ -96,6 +96,10 @@ The directive emits following events allowing further customization:
 * `sznAutocomplete-hide`: emitted each time the suggestions list hides
 * `sznAutocomplete-select`: emitted when some suggest item is selected. The selected item data is passed in the event data object
 
+## Validation
+`ngModel`/form-based validations are taken into account. Should the input field be invalid when typing in a query,
+ the request is not sent; a previously shown results list is also hidden.
+
 ## License
 
 Licensed under the MIT license

--- a/src/angular-szn-autocomplete.css
+++ b/src/angular-szn-autocomplete.css
@@ -32,7 +32,5 @@ input.szn-autocomplete-shadow-input {
 }
 
 .szn-autocomplete-results li .szn-autocomplete-match {
-    vertical-align: baseline;
     font-weight: bold;
-    color: #fff;
 }

--- a/src/angular-szn-autocomplete.css
+++ b/src/angular-szn-autocomplete.css
@@ -30,3 +30,9 @@ input.szn-autocomplete-shadow-input {
 	background: Highlight;
 	color: HighlightText;
 }
+
+.szn-autocomplete-results li .szn-autocomplete-match {
+    vertical-align: baseline;
+    font-weight: bold;
+    color: #fff;
+}

--- a/src/angular-szn-autocomplete.js
+++ b/src/angular-szn-autocomplete.js
@@ -11,7 +11,7 @@
 
 	var ngModule = angular.module( "angular-szn-autocomplete", ["angular-szn-autocomplete/template/shadowinput.html", "angular-szn-autocomplete/template/default.html"]);
 
-	var SznAutocompleteLink = function ($q, $timeout, $http, $compile, $templateCache, $scope, $elm, $attrs) {
+	var SznAutocompleteLink = function ($q, $timeout, $http, $compile, $templateCache, $scope, $elm, $attrs, ngModel) {
 		this._$q = $q;
 		this._$timeout = $timeout;
 		this._$http = $http;
@@ -19,6 +19,7 @@
 		this._$templateCache = $templateCache;
 		this._$scope = $scope;
 		this._$attrs = $attrs;
+		this._ngModelCtrl = ngModel;
 
 		this._$scope.$evalAsync((function ($elm) {
 
@@ -140,6 +141,8 @@
 	 * @param {Event} e
 	 */
 	SznAutocompleteLink.prototype._keyup = function (e) {
+		if (this._hideIfInvalid()) { return };
+
 		if (this.constructor.IGNORED_KEYS.indexOf(e.keyCode) == -1) {
 			if (this.constructor.NAVIGATION_KEYS.indexOf(e.keyCode) == -1) {
 				var query = e.target.value;
@@ -161,6 +164,8 @@
 	 * @param {Event} e
 	 */
 	SznAutocompleteLink.prototype._keydown = function (e) {
+		if (this._hideIfInvalid()) { return; }
+
 		if (this.constructor.IGNORED_KEYS.indexOf(e.keyCode) == -1) {
 			if (this.constructor.NAVIGATION_KEYS.indexOf(e.keyCode) != -1) {
 				this._navigate(e);
@@ -178,6 +183,13 @@
 				}
 			}
 		}
+	};
+
+	SznAutocompleteLink.prototype._hideIfInvalid = function() {
+		var isInvalid = (Object.getOwnPropertyNames(this._ngModelCtrl.$error).length > 0);
+		if (isInvalid) { this._hide(true); }
+
+		return isInvalid;
 	};
 
 	/**
@@ -466,8 +478,8 @@
 		return {
 			restrict: "AC",
 			require: 'ngModel',
-			link: function ($scope, $elm, $attrs) {
-				return new SznAutocompleteLink($q, $timeout, $http, $compile, $templateCache, $scope, $elm, $attrs);
+			link: function ($scope, $elm, $attrs, ngModel) {
+				return new SznAutocompleteLink($q, $timeout, $http, $compile, $templateCache, $scope, $elm, $attrs, ngModel);
 			}
 		};
 	}]);
@@ -521,7 +533,7 @@
             }
 
             var tags = {
-                bold: { open: "<b>", close: "</b>" },
+                bold:  { open: "<b>", close: "</b>" },
                 match: { open: "<span class='szn-autocomplete-match'>", close: "</span>" }
             };
 


### PR DESCRIPTION
- Added another optional way of highlighting the match in the result list 
- Added the functionality of ignoring key events, should the input field be invalid

On further thought, maybe remove the `color` from the new match-related class -- I thought there was a `background-color` set on the results list already.

P.S. : I think I screwed up the line endings, sorry. Also forgot to squash the readme commits.
