### PR TITLE
Hide menu on enter.

### DIFF
--- a/src/angular-szn-autocomplete.js
+++ b/src/angular-szn-autocomplete.js
@@ -283,6 +283,7 @@
 					if (item) {
 						this._select(item);
 					}
+					this._hide(true);
 				break;
 				case 38: // UP
 					e.preventDefault();


### PR DESCRIPTION
The assumption was made that when you hit enter, it will always be for navigational purposes and an item will be selected (causing the input to be cleared and the menu to hide). However, there is the use case that enter would be used for submitting a form (outside of this library). Then, if the input is cleared, the menu won't be hidden because we are listening for non-navigational keyups. I don't see any downside to always hide the menu when enter is pressed.
